### PR TITLE
fix(document.js): Allow revoked date to be passed to the DID-document

### DIFF
--- a/document.js
+++ b/document.js
@@ -100,8 +100,12 @@ class DIDDocument {
     // 5.0 Revoked
     // - https://w3c-ccg.github.io/did-spec/#delete-revoke
     // A timestamp value indicating when the identifier was revoked
-    if (opts.revoked && 'boolean' == typeof opts.revoked) {
-      this[$revoked] = new Date()
+    if (opts.revoked) {
+      if ('boolean' == typeof opts.revoked) {
+        this[$revoked] = new Date()
+      } else if ('string' == typeof opts.revoked) {
+        this[$revoked] = new Date(opts.revoked)
+      }
     }
   }
 


### PR DESCRIPTION
* This PR fixes a bug in which a revoked DDO being passed to `DIDDocument()` class would not set the revoked attribute